### PR TITLE
Replace yum shell with yum install to avoid silent failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,9 @@ FROM centos
 
 MAINTAINER Ben Parees <bparees@redhat.com>
 
-# Execute update && install in one yum command.
-#
-RUN ( \
-      echo "update"; \
-      echo "install tar unzip which bc lsof"; \
-      echo "install java-1.7.0-openjdk java-1.7.0-openjdk-devel"; \
-      echo "run"; \
-    ) | yum shell -y && yum clean all -y
+RUN yum update -y && yum install -y tar unzip bc which lsof \
+  java-1.7.0-openjdk java-1.7.0-openjdk-devel && \
+  yum clean all -y
 
 # Install Maven, Wildfly 8 and sample JEE application
 # The sample application will be built/run if no other source is bind-mounted to mask it.


### PR DESCRIPTION
I'm reverting my own change here because I haven' realized that the yum shell is not returning an error
when it fails. Instead it fails silently. So in case the package are not installed due to a network error, or an repository error, this step will just pass and then fail afterwards. This might produce unexpected errors (as it does with the ruby cartridge ;-)
