### PR TITLE
Download S2I instead of building it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,14 @@
-sudo: required
-
-language: go
-
-go:
-  - 1.6
+sudo: false
 
 services:
   - docker
 
 before_install:
-  # Build and install source-to-image (S2I)
-  - pushd /tmp
-  - git clone https://github.com/openshift/source-to-image source-to-image
-  - cd source-to-image
-  - hack/build-go.sh
-  - sudo mv _output/local/bin/linux/amd64/* /usr/local/bin
-  - popd
+  # Download and install source-to-image (S2I)
+  - mkdir $HOME/.bin
+  - curl -L https://github.com/openshift/source-to-image/releases/download/v1.0.5/source-to-image-v1.0.5-b731f95-linux-amd64.tar.gz |
+    tar -zx -C $HOME/.bin
+  - export PATH=$PATH:$HOME/.bin
 
 script:
   - make test


### PR DESCRIPTION
Download a binary release build of S2I instead of building from the
latest source tree during each image build. This should improve
build performance and reliability of builds.

Signed-off-by: Jonathan Yu <jawnsy@redhat.com>