### PR TITLE
Fix wrong null string check for MAVEN_ARGS_APPEND

### DIFF
--- a/10.0/s2i/bin/assemble
+++ b/10.0/s2i/bin/assemble
@@ -179,7 +179,7 @@ if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
   if [ -z "$MAVEN_ARGS" ]; then
     export MAVEN_ARGS="package -Popenshift -DskipTests -B"
   fi
-  if [ -z "$MAVEN_ARGS_APPEND" ]; then
+  if [ -n "$MAVEN_ARGS_APPEND" ]; then
     export MAVEN_ARGS="$MAVEN_ARGS $MAVEN_ARGS_APPEND"
   fi
   echo "Found pom.xml... attempting to build with 'mvn ${MAVEN_ARGS}'"
@@ -199,7 +199,7 @@ else
   echo "Copying binaries in source directory into $DEPLOY_DIR for later deployment..."
   cp $LOCAL_SOURCE_DIR/*.war $DEPLOY_DIR >& /dev/null
   chgrp -R 0 $DEPLOY_DIR
-  chmod -R g+rw $DEPLOY_DIR  
+  chmod -R g+rw $DEPLOY_DIR
 fi
 
 if [ -d $LOCAL_SOURCE_DIR/target ]; then

--- a/8.1/s2i/bin/assemble
+++ b/8.1/s2i/bin/assemble
@@ -179,7 +179,7 @@ if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
   if [ -z "$MAVEN_ARGS" ]; then
     export MAVEN_ARGS="package -Popenshift -DskipTests -B"
   fi
-  if [ -z "$MAVEN_ARGS_APPEND" ]; then
+  if [ -n "$MAVEN_ARGS_APPEND" ]; then
     export MAVEN_ARGS="$MAVEN_ARGS $MAVEN_ARGS_APPEND"
   fi
   echo "Found pom.xml... attempting to build with 'mvn ${MAVEN_ARGS}'"
@@ -199,7 +199,7 @@ else
   echo "Copying binaries in source directory into $DEPLOY_DIR for later deployment..."
   cp $LOCAL_SOURCE_DIR/*.war $DEPLOY_DIR >& /dev/null
   chgrp -R 0 $DEPLOY_DIR
-  chmod -R g+rw $DEPLOY_DIR  
+  chmod -R g+rw $DEPLOY_DIR
 fi
 
 if [ -d $LOCAL_SOURCE_DIR/target ]; then

--- a/9.0/s2i/bin/assemble
+++ b/9.0/s2i/bin/assemble
@@ -179,7 +179,7 @@ if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
   if [ -z "$MAVEN_ARGS" ]; then
     export MAVEN_ARGS="package -Popenshift -DskipTests -B"
   fi
-  if [ -z "$MAVEN_ARGS_APPEND" ]; then
+  if [ -n "$MAVEN_ARGS_APPEND" ]; then
     export MAVEN_ARGS="$MAVEN_ARGS $MAVEN_ARGS_APPEND"
   fi
   echo "Found pom.xml... attempting to build with 'mvn ${MAVEN_ARGS}'"
@@ -199,7 +199,7 @@ else
   echo "Copying binaries in source directory into $DEPLOY_DIR for later deployment..."
   cp $LOCAL_SOURCE_DIR/*.war $DEPLOY_DIR >& /dev/null
   chgrp -R 0 $DEPLOY_DIR
-  chmod -R g+rw $DEPLOY_DIR  
+  chmod -R g+rw $DEPLOY_DIR
 fi
 
 if [ -d $LOCAL_SOURCE_DIR/target ]; then


### PR DESCRIPTION
The env var "MAVEN_ARGS_APPEND" is exported only when it is null
using "-z" check which is wrong. The if statement should check
if the env var is not null using "-n" and then export it instead.

Signed-off-by: Vu Dinh <vdinh@redhat.com>