### PR TITLE
Updating docs and changing copy to move

### DIFF
--- a/10.0/s2i/bin/assemble
+++ b/10.0/s2i/bin/assemble
@@ -186,7 +186,7 @@ function configure_mirrors() {
   fi
 }
 
-function copy_artifacts() {
+function move_artifacts() {
   dir=$1
   types=
   shift
@@ -200,8 +200,8 @@ function copy_artifacts() {
     shift
     for t in $(echo $types | tr ";" "\n")
     do
-      echo "Copying all $t artifacts from $LOCAL_SOURCE_DIR/$d directory into $DEPLOY_DIR for later deployment..."
-      cp -v $LOCAL_SOURCE_DIR/$d/*.$t $DEPLOY_DIR 2> /dev/null
+      echo "Moving all $t artifacts from $LOCAL_SOURCE_DIR/$d directory into $DEPLOY_DIR for later deployment..."
+      mv -v $LOCAL_SOURCE_DIR/$d/*.$t $DEPLOY_DIR 2> /dev/null
       chgrp -fR 0 $LOCAL_SOURCE_DIR/$d/*.$t
       chmod -fR g+rw $LOCAL_SOURCE_DIR/$d/*.$t
     done
@@ -286,20 +286,20 @@ if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
     exit $ERR
   fi
 
-  echo "Copying built war files into $DEPLOY_DIR for later deployment..."
+  echo "Moving built war files into $DEPLOY_DIR for later deployment..."
   popd &> /dev/null
 else
-  echo "Copying binaries in source directory into $DEPLOY_DIR for later deployment..."
-  copy_artifacts "." war ear rar jar
+  echo "Moving binaries in source directory into $DEPLOY_DIR for later deployment..."
+  move_artifacts "." war ear rar jar
 fi
 
-# Copy built artifacts (if any!) from the target/ directory
+# Move built artifacts (if any!) from the target/ directory
 # (or $ARTIFACT_DIR if specified)
 if [ -d $LOCAL_SOURCE_DIR/$ARTIFACT_DIR ]; then
-  copy_artifacts "$ARTIFACT_DIR" war ear rar jar
+  move_artifacts "$ARTIFACT_DIR" war ear rar jar
 fi
 if [ -d $LOCAL_SOURCE_DIR/deployments ]; then
-  copy_artifacts "deployments" war ear rar jar
+  move_artifacts "deployments" war ear rar jar
 fi
 
 if [ -d $LOCAL_SOURCE_DIR/cfg ]; then

--- a/10.1/s2i/bin/assemble
+++ b/10.1/s2i/bin/assemble
@@ -186,7 +186,7 @@ function configure_mirrors() {
   fi
 }
 
-function copy_artifacts() {
+function move_artifacts() {
   dir=$1
   types=
   shift
@@ -200,14 +200,14 @@ function copy_artifacts() {
     shift
     for t in $(echo $types | tr ";" "\n")
     do
-      echo "Copying all $t artifacts from $LOCAL_SOURCE_DIR/$d directory into $DEPLOY_DIR for later deployment..."
-      cp -v $LOCAL_SOURCE_DIR/$d/*.$t $DEPLOY_DIR 2> /dev/null
+      echo "Moving all $t artifacts from $LOCAL_SOURCE_DIR/$d directory into $DEPLOY_DIR for later deployment..."
+      mv -v $LOCAL_SOURCE_DIR/$d/*.$t $DEPLOY_DIR 2> /dev/null
       chgrp -fR 0 $LOCAL_SOURCE_DIR/$d/*.$t
       chmod -fR g+rw $LOCAL_SOURCE_DIR/$d/*.$t
     done
   done
-}
 
+}
 ADMIN=admin
 PASSWORD=passw0rd_
 
@@ -286,21 +286,21 @@ if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
     exit $ERR
   fi
 
-  echo "Copying built war files into $DEPLOY_DIR for later deployment..."
+  echo "Moving built war files into $DEPLOY_DIR for later deployment..."
   popd &> /dev/null
 else
-  echo "Copying binaries in source directory into $DEPLOY_DIR for later deployment..."
-  copy_artifacts "." war ear rar jar
+  echo "Moving binaries in source directory into $DEPLOY_DIR for later deployment..."
+  move_artifacts "." war ear rar jar
 fi
 
-# Copy built artifacts (if any!) from the target/ directory
+# Move built artifacts (if any!) from the target/ directory
 # (or $ARTIFACT_DIR if specified)
 if [ -d $LOCAL_SOURCE_DIR/$ARTIFACT_DIR ]; then
-  copy_artifacts "$ARTIFACT_DIR" war ear rar jar
+  move_artifacts "$ARTIFACT_DIR" war ear rar jar
 fi
 
 if [ -d $LOCAL_SOURCE_DIR/deployments ]; then
-  copy_artifacts "deployments" war ear rar jar
+  move_artifacts "deployments" war ear rar jar
 fi
 
 if [ -d $LOCAL_SOURCE_DIR/cfg ]; then

--- a/8.1/s2i/bin/assemble
+++ b/8.1/s2i/bin/assemble
@@ -186,7 +186,7 @@ function configure_mirrors() {
   fi
 }
 
-function copy_artifacts() {
+function move_artifacts() {
   dir=$1
   types=
   shift
@@ -200,8 +200,8 @@ function copy_artifacts() {
     shift
     for t in $(echo $types | tr ";" "\n")
     do
-      echo "Copying all $t artifacts from $LOCAL_SOURCE_DIR/$d directory into $DEPLOY_DIR for later deployment..."
-      cp -v $LOCAL_SOURCE_DIR/$d/*.$t $DEPLOY_DIR 2> /dev/null
+      echo "Moving all $t artifacts from $LOCAL_SOURCE_DIR/$d directory into $DEPLOY_DIR for later deployment..."
+      mv -v $LOCAL_SOURCE_DIR/$d/*.$t $DEPLOY_DIR 2> /dev/null
       chgrp -fR 0 $LOCAL_SOURCE_DIR/$d/*.$t
       chmod -fR g+rw $LOCAL_SOURCE_DIR/$d/*.$t
     done
@@ -286,20 +286,20 @@ if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
     exit $ERR
   fi
 
-  echo "Copying built war files into $DEPLOY_DIR for later deployment..."
+  echo "Moving built war files into $DEPLOY_DIR for later deployment..."
   popd &> /dev/null
 else
-  echo "Copying binaries in source directory into $DEPLOY_DIR for later deployment..."
-  copy_artifacts "." war ear rar jar
+  echo "Moving binaries in source directory into $DEPLOY_DIR for later deployment..."
+  move_artifacts "." war ear rar jar
 fi
 
-# Copy built artifacts (if any!) from the target/ directory
+# Move built artifacts (if any!) from the target/ directory
 # (or $ARTIFACT_DIR if specified)
 if [ -d $LOCAL_SOURCE_DIR/$ARTIFACT_DIR ]; then
-  copy_artifacts "$ARTIFACT_DIR" war ear rar jar
+  move_artifacts "$ARTIFACT_DIR" war ear rar jar
 fi
 if [ -d $LOCAL_SOURCE_DIR/deployments ]; then
-  copy_artifacts "deployments" war ear rar jar
+  move_artifacts "deployments" war ear rar jar
 fi
 
 if [ -d $LOCAL_SOURCE_DIR/cfg ]; then

--- a/9.0/s2i/bin/assemble
+++ b/9.0/s2i/bin/assemble
@@ -186,7 +186,7 @@ function configure_mirrors() {
   fi
 }
 
-function copy_artifacts() {
+function move_artifacts() {
   dir=$1
   types=
   shift
@@ -200,8 +200,8 @@ function copy_artifacts() {
     shift
     for t in $(echo $types | tr ";" "\n")
     do
-      echo "Copying all $t artifacts from $LOCAL_SOURCE_DIR/$d directory into $DEPLOY_DIR for later deployment..."
-      cp -v $LOCAL_SOURCE_DIR/$d/*.$t $DEPLOY_DIR 2> /dev/null
+      echo "Moving all $t artifacts from $LOCAL_SOURCE_DIR/$d directory into $DEPLOY_DIR for later deployment..."
+      mv -v $LOCAL_SOURCE_DIR/$d/*.$t $DEPLOY_DIR 2> /dev/null
       chgrp -fR 0 $LOCAL_SOURCE_DIR/$d/*.$t
       chmod -fR g+rw $LOCAL_SOURCE_DIR/$d/*.$t
     done
@@ -286,20 +286,20 @@ if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
     exit $ERR
   fi
 
-  echo "Copying built war files into $DEPLOY_DIR for later deployment..."
+  echo "Moving built war files into $DEPLOY_DIR for later deployment..."
   popd &> /dev/null
 else
-  echo "Copying binaries in source directory into $DEPLOY_DIR for later deployment..."
-  copy_artifacts "." war ear rar jar
+  echo "Moving binaries in source directory into $DEPLOY_DIR for later deployment..."
+  move_artifacts "." war ear rar jar
 fi
 
-# Copy built artifacts (if any!) from the target/ directory
+# Move built artifacts (if any!) from the target/ directory
 # (or $ARTIFACT_DIR if specified)
 if [ -d $LOCAL_SOURCE_DIR/$ARTIFACT_DIR ]; then
-  copy_artifacts "$ARTIFACT_DIR" war ear rar jar
+  move_artifacts "$ARTIFACT_DIR" war ear rar jar
 fi
 if [ -d $LOCAL_SOURCE_DIR/deployments ]; then
-  copy_artifacts "deployments" war ear rar jar
+  move_artifacts "deployments" war ear rar jar
 fi
 
 if [ -d $LOCAL_SOURCE_DIR/cfg ]; then

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ WildFly versions currently provided are:
 * WildFly v8.1
 * WildFly v9.0
 * WildFly v10.0 (10.0.0 Final)
+* WildFly v10.1
 
 CentOS versions currently provided are:
 * CentOS7
@@ -38,6 +39,12 @@ or
 
 ```
 $ docker pull openshift/wildfly-100-centos7
+```
+
+or
+
+```
+$ docker pull openshift/wildfly-101-centos7
 ```
 
 To build a WildFly image from scratch, run:
@@ -97,18 +104,18 @@ Repository organization
 
         *   **assemble**
 
-          Is used to restore the build artifacts from the previous built (in case of
+          Is used to restore the build artifacts from the previous build (in case of
           'incremental build'), to install the sources into location from where the
           application will be run and prepare the application for deployment (eg.
           installing maven dependencies, building java code, etc..).
 
-          In addition, the assemble script will copy artifacts provided in the
+          In addition, the assemble script will distribute artifacts provided in the
           application source project into the Wildfly installation:
 
           Wildfly configuration files from the <application source>/cfg are copied
           into the wildfly configuration directory.
 
-          Pre-built war files from the <application source>/deployments are copied
+          Pre-built war files from the <application source>/deployments are moved
           into the wildfly deployment directory.
 
           Wildfly modules from the <application source>/provided_modules are copied
@@ -161,6 +168,11 @@ Repository organization
 
     Folder containing scripts which are responsible for the build and test actions performed by the `Makefile`.
 
+Hot Deploy
+------------------------
+
+Hot deploy is enabled by default for all WildFly versions.  
+To deploy a new version of your web application without restarting, you will need to either rsync or scp your war/ear/rar/jar file to the /wildfly/standalone/deployments directory within your pod.
 
 Image name structure
 ------------------------


### PR DESCRIPTION
Updating the README to further clarify the instructions for using
hot deploy with WildFly.

Changed the copy_artifacts function in all assemble scripts to
move_artifacts instead of keeping two copies of the artifact around
which could confuse users about where to rsync or scp their artifacts
to use the hot deploy feature.

Fixes #115 