### PR TITLE
Custom default datasource (ExampleDS)

### DIFF
--- a/10.0/contrib/wfbin/standalone.conf
+++ b/10.0/contrib/wfbin/standalone.conf
@@ -19,6 +19,18 @@ then
   export OPENSHIFT_DEFAULT_DATASOURCE=$DEFAULT_DATASOURCE
 fi
 
+# default datasource
+if [ -n "$DATASOURCE" ]
+then
+  export OPENSHIFT_DATASOURCE=$DATASOURCE
+else
+  export OPENSHIFT_DATASOURCE="ExampleDS"
+fi
+if [ ! -n "${OPENSHIFT_DEFAULT_DATASOURCE}" ]
+then
+  export OPENSHIFT_DEFAULT_DATASOURCE=${OPENSHIFT_DATASOURCE}
+fi
+
 # mysql db container must be linked w/ alias "mysql"
 export MYSQL_ENABLED="false"
 if [ -n "$MYSQL_DATABASE" ]

--- a/10.0/contrib/wfbin/standalone.conf
+++ b/10.0/contrib/wfbin/standalone.conf
@@ -20,15 +20,12 @@ then
 fi
 
 # default datasource
-if [ -n "$EXAMPLE_DATASOURCE" ]
-then
-  export OPENSHIFT_DATASOURCE=$EXAMPLE_DATASOURCE
-else
-  export OPENSHIFT_DATASOURCE="ExampleDS"
+if [ -z "$EXAMPLE_DATASOURCE" ]; then
+  export EXAMPLE_DATASOURCE="ExampleDS"
 fi
 if [ ! -n "${OPENSHIFT_DEFAULT_DATASOURCE}" ]
 then
-  export OPENSHIFT_DEFAULT_DATASOURCE=${OPENSHIFT_DATASOURCE}
+  export OPENSHIFT_DEFAULT_DATASOURCE=${EXAMPLE_DATASOURCE}
 fi
 
 # mysql db container must be linked w/ alias "mysql"

--- a/10.0/contrib/wfbin/standalone.conf
+++ b/10.0/contrib/wfbin/standalone.conf
@@ -20,9 +20,9 @@ then
 fi
 
 # default datasource
-if [ -n "$DATASOURCE" ]
+if [ -n "$EXAMPLE_DATASOURCE" ]
 then
-  export OPENSHIFT_DATASOURCE=$DATASOURCE
+  export OPENSHIFT_DATASOURCE=$EXAMPLE_DATASOURCE
 else
   export OPENSHIFT_DATASOURCE="ExampleDS"
 fi

--- a/10.0/contrib/wfcfg/standalone.xml
+++ b/10.0/contrib/wfcfg/standalone.xml
@@ -131,7 +131,7 @@
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:4.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" pool-name="${env.OPENSHIFT_DATASOURCE}" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/${env.EXAMPLE_DATASOURCE}" pool-name="${env.EXAMPLE_DATASOURCE}" enabled="true" use-java-context="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>
@@ -205,7 +205,7 @@
                     <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" keepalive-time="3000"/>
                 </managed-scheduled-executor-services>
             </concurrent>
-            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/${env.EXAMPLE_DATASOURCE}" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
             <session-bean>

--- a/10.0/contrib/wfcfg/standalone.xml
+++ b/10.0/contrib/wfcfg/standalone.xml
@@ -131,7 +131,7 @@
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:4.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" pool-name="${env.OPENSHIFT_DATASOURCE}" enabled="true" use-java-context="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>
@@ -205,7 +205,7 @@
                     <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" keepalive-time="3000"/>
                 </managed-scheduled-executor-services>
             </concurrent>
-            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
             <session-bean>

--- a/10.1/contrib/wfbin/standalone.conf
+++ b/10.1/contrib/wfbin/standalone.conf
@@ -19,6 +19,18 @@ then
   export OPENSHIFT_DEFAULT_DATASOURCE=$DEFAULT_DATASOURCE
 fi
 
+# default datasource
+if [ -n "$DATASOURCE" ]
+then
+  export OPENSHIFT_DATASOURCE=$DATASOURCE
+else
+  export OPENSHIFT_DATASOURCE="ExampleDS"
+fi
+if [ ! -n "${OPENSHIFT_DEFAULT_DATASOURCE}" ]
+then
+  export OPENSHIFT_DEFAULT_DATASOURCE=${OPENSHIFT_DATASOURCE}
+fi
+
 # mysql db container must be linked w/ alias "mysql"
 export MYSQL_ENABLED="false"
 if [ -n "$MYSQL_DATABASE" ]

--- a/10.1/contrib/wfbin/standalone.conf
+++ b/10.1/contrib/wfbin/standalone.conf
@@ -20,15 +20,12 @@ then
 fi
 
 # default datasource
-if [ -n "$EXAMPLE_DATASOURCE" ]
-then
-  export OPENSHIFT_DATASOURCE=$EXAMPLE_DATASOURCE
-else
-  export OPENSHIFT_DATASOURCE="ExampleDS"
+if [ -z "$EXAMPLE_DATASOURCE" ]; then
+  export EXAMPLE_DATASOURCE="ExampleDS"
 fi
 if [ ! -n "${OPENSHIFT_DEFAULT_DATASOURCE}" ]
 then
-  export OPENSHIFT_DEFAULT_DATASOURCE=${OPENSHIFT_DATASOURCE}
+  export OPENSHIFT_DEFAULT_DATASOURCE=${EXAMPLE_DATASOURCE}
 fi
 
 # mysql db container must be linked w/ alias "mysql"

--- a/10.1/contrib/wfbin/standalone.conf
+++ b/10.1/contrib/wfbin/standalone.conf
@@ -20,9 +20,9 @@ then
 fi
 
 # default datasource
-if [ -n "$DATASOURCE" ]
+if [ -n "$EXAMPLE_DATASOURCE" ]
 then
-  export OPENSHIFT_DATASOURCE=$DATASOURCE
+  export OPENSHIFT_DATASOURCE=$EXAMPLE_DATASOURCE
 else
   export OPENSHIFT_DATASOURCE="ExampleDS"
 fi

--- a/10.1/contrib/wfcfg/standalone.xml
+++ b/10.1/contrib/wfcfg/standalone.xml
@@ -131,7 +131,7 @@
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:4.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" pool-name="${env.OPENSHIFT_DATASOURCE}" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/${env.EXAMPLE_DATASOURCE}" pool-name="${env.EXAMPLE_DATASOURCE}" enabled="true" use-java-context="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>
@@ -205,7 +205,7 @@
                     <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" keepalive-time="3000"/>
                 </managed-scheduled-executor-services>
             </concurrent>
-            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/${env.EXAMPLE_DATASOURCE}" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
             <session-bean>

--- a/10.1/contrib/wfcfg/standalone.xml
+++ b/10.1/contrib/wfcfg/standalone.xml
@@ -131,7 +131,7 @@
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:4.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" pool-name="${env.OPENSHIFT_DATASOURCE}" enabled="true" use-java-context="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>
@@ -205,7 +205,7 @@
                     <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" keepalive-time="3000"/>
                 </managed-scheduled-executor-services>
             </concurrent>
-            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
             <session-bean>

--- a/8.1/contrib/wfbin/standalone.conf
+++ b/8.1/contrib/wfbin/standalone.conf
@@ -21,6 +21,18 @@ then
   export OPENSHIFT_DEFAULT_DATASOURCE=$DEFAULT_DATASOURCE
 fi
 
+# default datasource
+if [ -n "$DATASOURCE" ]
+then
+  export OPENSHIFT_DATASOURCE=$DATASOURCE
+else
+  export OPENSHIFT_DATASOURCE="ExampleDS"
+fi
+if [ ! -n "${OPENSHIFT_DEFAULT_DATASOURCE}" ]
+then
+  export OPENSHIFT_DEFAULT_DATASOURCE=${OPENSHIFT_DATASOURCE}
+fi
+
 # mysql db container must be linked w/ alias "mysql"
 export MYSQL_ENABLED="false"
 if [ -n "$MYSQL_DATABASE" ]

--- a/8.1/contrib/wfbin/standalone.conf
+++ b/8.1/contrib/wfbin/standalone.conf
@@ -22,9 +22,9 @@ then
 fi
 
 # default datasource
-if [ -n "$DATASOURCE" ]
+if [ -n "$EXAMPLE_DATASOURCE" ]
 then
-  export OPENSHIFT_DATASOURCE=$DATASOURCE
+  export OPENSHIFT_DATASOURCE=$EXAMPLE_DATASOURCE
 else
   export OPENSHIFT_DATASOURCE="ExampleDS"
 fi

--- a/8.1/contrib/wfbin/standalone.conf
+++ b/8.1/contrib/wfbin/standalone.conf
@@ -22,15 +22,12 @@ then
 fi
 
 # default datasource
-if [ -n "$EXAMPLE_DATASOURCE" ]
-then
-  export OPENSHIFT_DATASOURCE=$EXAMPLE_DATASOURCE
-else
-  export OPENSHIFT_DATASOURCE="ExampleDS"
+if [ -z "$EXAMPLE_DATASOURCE" ]; then
+  export EXAMPLE_DATASOURCE="ExampleDS"
 fi
 if [ ! -n "${OPENSHIFT_DEFAULT_DATASOURCE}" ]
 then
-  export OPENSHIFT_DEFAULT_DATASOURCE=${OPENSHIFT_DATASOURCE}
+  export OPENSHIFT_DEFAULT_DATASOURCE=${EXAMPLE_DATASOURCE}
 fi
 
 # mysql db container must be linked w/ alias "mysql"

--- a/8.1/contrib/wfcfg/standalone.xml
+++ b/8.1/contrib/wfcfg/standalone.xml
@@ -137,7 +137,7 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:datasources:2.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" pool-name="${env.OPENSHIFT_DATASOURCE}" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/${env.EXAMPLE_DATASOURCE}" pool-name="${env.EXAMPLE_DATASOURCE}" enabled="true" use-java-context="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>

--- a/8.1/contrib/wfcfg/standalone.xml
+++ b/8.1/contrib/wfcfg/standalone.xml
@@ -137,7 +137,7 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:datasources:2.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" pool-name="${env.OPENSHIFT_DATASOURCE}" enabled="true" use-java-context="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>

--- a/9.0/contrib/wfbin/standalone.conf
+++ b/9.0/contrib/wfbin/standalone.conf
@@ -21,6 +21,18 @@ then
   export OPENSHIFT_DEFAULT_DATASOURCE=$DEFAULT_DATASOURCE
 fi
 
+# default datasource
+if [ -n "$DATASOURCE" ]
+then
+  export OPENSHIFT_DATASOURCE=$DATASOURCE
+else
+  export OPENSHIFT_DATASOURCE="ExampleDS"
+fi
+if [ ! -n "${OPENSHIFT_DEFAULT_DATASOURCE}" ]
+then
+  export OPENSHIFT_DEFAULT_DATASOURCE=${OPENSHIFT_DATASOURCE}
+fi
+
 # mysql db container must be linked w/ alias "mysql"
 export MYSQL_ENABLED="false"
 if [ -n "$MYSQL_DATABASE" ]

--- a/9.0/contrib/wfbin/standalone.conf
+++ b/9.0/contrib/wfbin/standalone.conf
@@ -22,9 +22,9 @@ then
 fi
 
 # default datasource
-if [ -n "$DATASOURCE" ]
+if [ -n "$EXAMPLE_DATASOURCE" ]
 then
-  export OPENSHIFT_DATASOURCE=$DATASOURCE
+  export OPENSHIFT_DATASOURCE=$EXAMPLE_DATASOURCE
 else
   export OPENSHIFT_DATASOURCE="ExampleDS"
 fi

--- a/9.0/contrib/wfbin/standalone.conf
+++ b/9.0/contrib/wfbin/standalone.conf
@@ -22,15 +22,12 @@ then
 fi
 
 # default datasource
-if [ -n "$EXAMPLE_DATASOURCE" ]
-then
-  export OPENSHIFT_DATASOURCE=$EXAMPLE_DATASOURCE
-else
-  export OPENSHIFT_DATASOURCE="ExampleDS"
+if [ -z "$EXAMPLE_DATASOURCE" ]; then
+  export EXAMPLE_DATASOURCE="ExampleDS"
 fi
 if [ ! -n "${OPENSHIFT_DEFAULT_DATASOURCE}" ]
 then
-  export OPENSHIFT_DEFAULT_DATASOURCE=${OPENSHIFT_DATASOURCE}
+  export OPENSHIFT_DEFAULT_DATASOURCE=${EXAMPLE_DATASOURCE}
 fi
 
 # mysql db container must be linked w/ alias "mysql"

--- a/9.0/contrib/wfcfg/standalone.xml
+++ b/9.0/contrib/wfcfg/standalone.xml
@@ -137,7 +137,7 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:datasources:2.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" pool-name="${env.OPENSHIFT_DATASOURCE}" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/${env.EXAMPLE_DATASOURCE}" pool-name="${env.EXAMPLE_DATASOURCE}" enabled="true" use-java-context="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>

--- a/9.0/contrib/wfcfg/standalone.xml
+++ b/9.0/contrib/wfcfg/standalone.xml
@@ -137,7 +137,7 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:datasources:2.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/${env.OPENSHIFT_DATASOURCE}" pool-name="${env.OPENSHIFT_DATASOURCE}" enabled="true" use-java-context="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>


### PR DESCRIPTION
This pull request is for customize the name of the default datasource called ExampleDS for default.

Because there are POSTGRESQL_DATASOURCE and MYSQL_DATASOURCE env variables for define the name of the datasources so I decided to named this variable just as DATASOURCE.

the default datasource name can be changed passing an env variable called DATASOURCE, for example:

DATASOURCE=MyCustomDS

fixes https://github.com/openshift-s2i/s2i-wildfly/issues/125