### PR TITLE
Replace maven version 3.5.0 with 3.5.2 

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER Ben Parees <bparees@redhat.com>
 EXPOSE 8080
 
 ENV WILDFLY_VERSION=11.0.0.Final \
-    MAVEN_VERSION=3.5.0
+    MAVEN_VERSION=3.5.2
 
 LABEL io.k8s.description="Platform for building and running JEE applications on WildFly 11.0.0.Final" \
       io.k8s.display-name="WildFly 11.0.0.Final" \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ WildFly versions currently provided are:
 * WildFly v9.0 (deprecated)
 * WildFly v10.0 (10.0.0 Final)
 * WildFly v10.1
+* WildFly v11.0
 
 CentOS versions currently provided are:
 * CentOS7


### PR DESCRIPTION
Currently s2i image build for v11.0 tries to use maven 3.5.0 that does
not exist on the repo of apache.org. Due to this, building the image
always fail. This patch replaces the maven version 3.5.0 with 3.5.2.

fixes https://github.com/openshift-s2i/s2i-wildfly/issues/150