### PR TITLE
Adding support for runtime assembly

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -14,8 +14,10 @@ LABEL io.k8s.description="Platform for building and running JEE applications on 
       io.k8s.display-name="WildFly 10.0.0.Final" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,wildfly,wildfly10" \
+      io.openshift.s2i.assemble-input-files="/wildfly/standalone/deployments;/wildfly/standalone/configuration" \
       io.openshift.s2i.destination="/opt/s2i/destination" \
-      com.redhat.deployments-dir="/wildfly/standalone/deployments"
+      com.redhat.deployments-dir="/wildfly/standalone/deployments" \
+      maintainer="Ben Parees <bparees@redhat.com>"
 
 # Install Maven, Wildfly 10
 RUN INSTALL_PKGS="tar unzip bc which lsof java-1.8.0-openjdk java-1.8.0-openjdk-devel" && \

--- a/10.0/s2i/bin/assemble-runtime
+++ b/10.0/s2i/bin/assemble-runtime
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Asssembling runtime environment..."
+DEPLOY_DIR=/wildfly/standalone/deployments
+CONFIG_DIR=/wildfly/standalone/configuration
+MODULES_DIR=/wildfly/provided_modules
+
+echo "Creating deployment directories..."
+mkdir -p $DEPLOY_DIR
+mkdir -p $CONFIG_DIR
+mkdir -p $MODULES_DIR
+
+LOCAL_DIR="${HOME}"
+
+if [ -d $LOCAL_DIR/deployments ]; then
+    echo "Copying deployments..."
+    cp -r -v $LOCAL_DIR/deployments/* $DEPLOY_DIR
+fi
+
+if [ -d $LOCAL_DIR/configuration ]; then
+    echo "Copying configurations..."
+    cp -r -v $LOCAL_DIR/configuration/* $CONFIG_DIR
+fi
+
+if [ -d $LOCAL_DIR/provided_modules ]; then
+    echo "Copying modules..."
+    cp -r -v $LOCAL_DIR/provided_modules/* $MODULES_DIR
+fi

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -14,8 +14,10 @@ LABEL io.k8s.description="Platform for building and running JEE applications on 
       io.k8s.display-name="WildFly 10.1.0.Final" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,wildfly,wildfly10" \
+      io.openshift.s2i.assemble-input-files="/wildfly/standalone/deployments;/wildfly/standalone/configuration" \
       io.openshift.s2i.destination="/opt/s2i/destination" \
-      com.redhat.deployments-dir="/wildfly/standalone/deployments"
+      com.redhat.deployments-dir="/wildfly/standalone/deployments" \
+      maintainer="Ben Parees <bparees@redhat.com>"
 
 # Install Maven, Wildfly 10
 RUN INSTALL_PKGS="tar unzip bc which lsof java-1.8.0-openjdk java-1.8.0-openjdk-devel" && \

--- a/10.1/s2i/bin/assemble-runtime
+++ b/10.1/s2i/bin/assemble-runtime
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Asssembling runtime environment..."
+DEPLOY_DIR=/wildfly/standalone/deployments
+CONFIG_DIR=/wildfly/standalone/configuration
+MODULES_DIR=/wildfly/provided_modules
+
+echo "Creating deployment directories..."
+mkdir -p $DEPLOY_DIR
+mkdir -p $CONFIG_DIR
+mkdir -p $MODULES_DIR
+
+LOCAL_DIR="${HOME}"
+
+if [ -d $LOCAL_DIR/deployments ]; then
+    echo "Copying deployments..."
+    cp -r -v $LOCAL_DIR/deployments/* $DEPLOY_DIR
+fi
+
+if [ -d $LOCAL_DIR/configuration ]; then
+    echo "Copying configurations..."
+    cp -r -v $LOCAL_DIR/configuration/* $CONFIG_DIR
+fi
+
+if [ -d $LOCAL_DIR/provided_modules ]; then
+    echo "Copying modules..."
+    cp -r -v $LOCAL_DIR/provided_modules/* $MODULES_DIR
+fi

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -14,8 +14,10 @@ LABEL io.k8s.description="Platform for building and running JEE applications on 
       io.k8s.display-name="WildFly 11.0.0.Final" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,wildfly,wildfly11" \
+      io.openshift.s2i.assemble-input-files="/wildfly/standalone/deployments;/wildfly/standalone/configuration" \
       io.openshift.s2i.destination="/opt/s2i/destination" \
-      com.redhat.deployments-dir="/wildfly/standalone/deployments"
+      com.redhat.deployments-dir="/wildfly/standalone/deployments" \
+      maintainer="Ben Parees <bparees@redhat.com>"
 
 # Install Maven, Wildfly 
 RUN INSTALL_PKGS="tar unzip bc which lsof java-1.8.0-openjdk java-1.8.0-openjdk-devel" && \

--- a/11.0/s2i/bin/assemble-runtime
+++ b/11.0/s2i/bin/assemble-runtime
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Asssembling runtime environment..."
+DEPLOY_DIR=/wildfly/standalone/deployments
+CONFIG_DIR=/wildfly/standalone/configuration
+MODULES_DIR=/wildfly/provided_modules
+
+echo "Creating deployment directories..."
+mkdir -p $DEPLOY_DIR
+mkdir -p $CONFIG_DIR
+mkdir -p $MODULES_DIR
+
+LOCAL_DIR="${HOME}"
+
+if [ -d $LOCAL_DIR/deployments ]; then
+    echo "Copying deployments..."
+    cp -r -v $LOCAL_DIR/deployments/* $DEPLOY_DIR
+fi
+
+if [ -d $LOCAL_DIR/configuration ]; then
+    echo "Copying configurations..."
+    cp -r -v $LOCAL_DIR/configuration/* $CONFIG_DIR
+fi
+
+if [ -d $LOCAL_DIR/provided_modules ]; then
+    echo "Copying modules..."
+    cp -r -v $LOCAL_DIR/provided_modules/* $MODULES_DIR
+fi

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -14,8 +14,10 @@ LABEL io.k8s.description="Platform for building and running JEE applications on 
       io.k8s.display-name="WildFly 12.0.0.Final" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,wildfly,wildfly12" \
+      io.openshift.s2i.assemble-input-files="/wildfly/standalone/deployments;/wildfly/standalone/configuration" \
       io.openshift.s2i.destination="/opt/s2i/destination" \
-      com.redhat.deployments-dir="/wildfly/standalone/deployments"
+      com.redhat.deployments-dir="/wildfly/standalone/deployments" \
+      maintainer="Ben Parees <bparees@redhat.com>"
 
 # Install Maven, Wildfly
 RUN INSTALL_PKGS="tar unzip bc which lsof java-1.8.0-openjdk java-1.8.0-openjdk-devel" && \

--- a/12.0/s2i/bin/assemble-runtime
+++ b/12.0/s2i/bin/assemble-runtime
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Asssembling runtime environment..."
+DEPLOY_DIR=/wildfly/standalone/deployments
+CONFIG_DIR=/wildfly/standalone/configuration
+MODULES_DIR=/wildfly/provided_modules
+
+echo "Creating deployment directories..."
+mkdir -p $DEPLOY_DIR
+mkdir -p $CONFIG_DIR
+mkdir -p $MODULES_DIR
+
+LOCAL_DIR="${HOME}"
+
+if [ -d $LOCAL_DIR/deployments ]; then
+    echo "Copying deployments..."
+    cp -r -v $LOCAL_DIR/deployments/* $DEPLOY_DIR
+fi
+
+if [ -d $LOCAL_DIR/configuration ]; then
+    echo "Copying configurations..."
+    cp -r -v $LOCAL_DIR/configuration/* $CONFIG_DIR
+fi
+
+if [ -d $LOCAL_DIR/provided_modules ]; then
+    echo "Copying modules..."
+    cp -r -v $LOCAL_DIR/provided_modules/* $MODULES_DIR
+fi

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -15,8 +15,10 @@ LABEL io.k8s.description="Platform for building and running JEE applications on 
       io.k8s.display-name="WildFly 8.1" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,wildfly,wildfly81" \
+      io.openshift.s2i.assemble-input-files="/wildfly/standalone/deployments;/wildfly/standalone/configuration" \
       io.openshift.s2i.destination="/opt/s2i/destination" \
-      com.redhat.deployments-dir="/wildfly/standalone/deployments"
+      com.redhat.deployments-dir="/wildfly/standalone/deployments" \
+      maintainer="Ben Parees <bparees@redhat.com>"
 
 # Install Maven, Wildfly 8
 RUN INSTALL_PKGS="tar unzip bc which lsof java-1.8.0-openjdk java-1.8.0-openjdk-devel" && \

--- a/8.1/s2i/bin/assemble-runtime
+++ b/8.1/s2i/bin/assemble-runtime
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Asssembling runtime environment..."
+DEPLOY_DIR=/wildfly/standalone/deployments
+CONFIG_DIR=/wildfly/standalone/configuration
+MODULES_DIR=/wildfly/provided_modules
+
+echo "Creating deployment directories..."
+mkdir -p $DEPLOY_DIR
+mkdir -p $CONFIG_DIR
+mkdir -p $MODULES_DIR
+
+LOCAL_DIR="${HOME}"
+
+if [ -d $LOCAL_DIR/deployments ]; then
+    echo "Copying deployments..."
+    cp -r -v $LOCAL_DIR/deployments/* $DEPLOY_DIR
+fi
+
+if [ -d $LOCAL_DIR/configuration ]; then
+    echo "Copying configurations..."
+    cp -r -v $LOCAL_DIR/configuration/* $CONFIG_DIR
+fi
+
+if [ -d $LOCAL_DIR/provided_modules ]; then
+    echo "Copying modules..."
+    cp -r -v $LOCAL_DIR/provided_modules/* $MODULES_DIR
+fi

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -15,8 +15,10 @@ LABEL io.k8s.description="Platform for building and running JEE applications on 
       io.k8s.display-name="WildFly 9.0" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,wildfly,wildfly90" \
+      io.openshift.s2i.assemble-input-files="/wildfly/standalone/deployments;/wildfly/standalone/configuration" \
       io.openshift.s2i.destination="/opt/s2i/destination" \
-      com.redhat.deployments-dir="/wildfly/standalone/deployments"
+      com.redhat.deployments-dir="/wildfly/standalone/deployments" \
+      maintainer="Ben Parees <bparees@redhat.com"
 
 # Install Maven, Wildfly 9
 RUN INSTALL_PKGS="tar unzip bc which lsof java-1.8.0-openjdk java-1.8.0-openjdk-devel" && \

--- a/9.0/s2i/bin/assemble-runtime
+++ b/9.0/s2i/bin/assemble-runtime
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Asssembling runtime environment..."
+DEPLOY_DIR=/wildfly/standalone/deployments
+CONFIG_DIR=/wildfly/standalone/configuration
+MODULES_DIR=/wildfly/provided_modules
+
+echo "Creating deployment directories..."
+mkdir -p $DEPLOY_DIR
+mkdir -p $CONFIG_DIR
+mkdir -p $MODULES_DIR
+
+LOCAL_DIR="${HOME}"
+
+if [ -d $LOCAL_DIR/deployments ]; then
+    echo "Copying deployments..."
+    cp -r -v $LOCAL_DIR/deployments/* $DEPLOY_DIR
+fi
+
+if [ -d $LOCAL_DIR/configuration ]; then
+    echo "Copying configurations..."
+    cp -r -v $LOCAL_DIR/configuration/* $CONFIG_DIR
+fi
+
+if [ -d $LOCAL_DIR/provided_modules ]; then
+    echo "Copying modules..."
+    cp -r -v $LOCAL_DIR/provided_modules/* $MODULES_DIR
+fi

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ $ s2i build git://github.com/openshift/openshift-jee-sample openshift/wildfly-10
 $ docker run -p 8080:8080 wildflytest
 ```
 
+You can also use this as a [S2I Runtime Image](https://github.com/openshift/source-to-image/blob/master/docs/runtime_image.md),
+which will produce a final image with source code omitted:
+
+```
+$ s2i build git://github.com/openshift/openshift-jee-sample openshift/wildfly-101-centos7 wildflytest --runtime-image openshift/wildfly-101-centos7
+$ docker run -p 8080:8080 wildflytest
+```
+
 **Accessing the application:**
 ```
 $ curl 127.0.0.1:8080
@@ -112,6 +120,20 @@ Repository organization
           Wildfly modules from the <application source>/provided_modules are copied
           into the wildfly modules directory.
 
+        *   **assemble-runtime**
+          
+          This script will accept standard Wildfly build artifacts as input, and copy 
+          them into a separate runtime image for deployment. 
+          Items in following directories can be accepted as runtime artifacts:
+          
+          `deployments/` - these are copied into the wildfly deployments directory
+
+          `configuration/` - these are copied into the wildfly configuration directory
+
+          `provided_modules/` - these are copied into the wildfly provided modules directory.
+          
+          See the [S2I runtime image documentation](https://github.com/openshift/source-to-image/blob/master/docs/runtime_image.md)
+          for further details.
 
         *   **run**
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 # This script is used to build and test the OpenShift Docker images.
 #
-# Name of resulting image will be: 'NAMESPACE/BASE_IMAGE_NAME-VERSION-OS'.
+# Name of resulting image will be: 'DOCKER_REPO/BASE_IMAGE_NAME-VERSION-OS'.
+# Default docker repo is openshift.
 #
 # BASE_IMAGE_NAME - Usually name of the main component within container.
 # OS - Specifies distribution - "rhel7" or "centos7"
@@ -28,7 +29,7 @@ test -z "$BASE_IMAGE_NAME" && {
   BASE_IMAGE_NAME="${BASE_DIR_NAME#s2i-}"
 }
 
-NAMESPACE="openshift/"
+NAMESPACE="${DOCKER_REPO:-openshift}/"
 
 # Cleanup the temporary Dockerfile created by docker build with version
 trap "rm -f ${DOCKERFILE_PATH}.version" SIGINT SIGQUIT EXIT


### PR DESCRIPTION
This PR adds the `assembly-runtime` script to `s2i-wildfly`, which provides support for runtime images in Wildfly s2i builds.

See [S2I Runtime Images](https://github.com/openshift/source-to-image/blob/master/docs/runtime_image.md) for details.