### PR TITLE
Updated to reflect the actual location of modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ Repository organization
           Pre-built war files from the <application source>/deployments are moved
           into the wildfly deployment directory.
 
-          Wildfly modules from the <application source>/provided_modules are copied
-          into the wildfly modules directory.
+          Wildfly modules from the <application source>/modules are copied
+          into the wildfly provided modules directory.
 
         *   **assemble-runtime**
 


### PR DESCRIPTION
`assemble` copies modules not from provided_modules, but from modules.

This was introduced here: https://github.com/weltonrodrigo/s2i-wildfly/commit/79881a8f96ab44a14b1431352344f87147080b7b#diff-86b6cd13190bafd3993e8bf3db0c1945R340