### PR TITLE
Use Pod IP address for the public interface

### DIFF
--- a/16.0/contrib/wfbin/standalone.conf
+++ b/16.0/contrib/wfbin/standalone.conf
@@ -167,7 +167,7 @@ if [ "x$JBOSS_MODULES_SYSTEM_PKGS" = "x" ]; then
 fi
 
 if [ -z "$JAVA_OPTS" ]; then
-   JAVA_OPTS="$memory_options -DOPENSHIFT_APP_UUID=${OPENSHIFT_APP_UUID} -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true -Dorg.jboss.resolver.warning=true -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8 -Djboss.node.name=${OPENSHIFT_HOSTNAME} -Djgroups.bind_addr=0.0.0.0 -Dorg.apache.coyote.http11.Http11Protocol.COMPRESSION=on"
+   JAVA_OPTS="$memory_options -DOPENSHIFT_APP_UUID=${OPENSHIFT_APP_UUID} -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true -Dorg.jboss.resolver.warning=true -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8 -Djboss.node.name=${OPENSHIFT_HOSTNAME} -Dorg.apache.coyote.http11.Http11Protocol.COMPRESSION=on"
    if [ ! -z "$ENABLE_JPDA" ]; then
       JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=0.0.0.0:8787,server=y,suspend=n ${JAVA_OPTS}"
    fi

--- a/16.0/s2i/bin/run
+++ b/16.0/s2i/bin/run
@@ -1,2 +1,3 @@
 #!/bin/bash
-exec /wildfly/bin/standalone.sh -b 0.0.0.0 -bmanagement 0.0.0.0
+# use the Pod IP address for the public interface
+exec /wildfly/bin/standalone.sh -b $(hostname -i) -bmanagement 0.0.0.0


### PR DESCRIPTION
Use `hostname -i` to determine the IP address of the Pod and bind the
WildFly public interface to it.

Do not bind jgroups.bind_address to 0.0.0.0 (that is incorrect for
JGroups).
Instead, if JGroups subsystem is defined, the standalone configuration
can attach its socket-binding to the public interface so that the Pod IP
addres is properly used to identiy JGroups nodes.